### PR TITLE
Add Windows one-click build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Run `cargo check` in the repo root to verify all Rust crates.
 Install with `cargo install --path crates/clappy-cli` and run `clappy --provider ollama --model llama3`.
 The CLI features a dynamic command router. Enter a shell name (`bash`, `pwsh`, `cmd`) to spawn that shell, `/model <name>` to hot-swap the model, or any natural language which will be converted to a shell command using the selected provider. Telemetry is disabled unless `--insecure-telemetry` is passed.
 
+## Windows Build
+Run `pwsh scripts/build_setup.ps1` to create a single `clappy.exe` in the `dist` folder. The script bundles the Tauri MSI with NSIS and `pkgforge` for a one-click installer.
+
 ```bash
 > winget doesnt work
 # AI: "Try 'winget source reset --force'"

--- a/scripts/build_setup.ps1
+++ b/scripts/build_setup.ps1
@@ -1,0 +1,4 @@
+cargo tauri build --windows --release
+$msi = Get-ChildItem target\release\bundle\msi\*.msi
+& makensis /DMSI="$msi" installer.nsi
+& pkgforge pack installer\nsis\clappy_installer.exe -o dist\clappy.exe


### PR DESCRIPTION
## Summary
- add `scripts/build_setup.ps1` to wrap Tauri MSI into a portable exe
- document the Windows build in README

## Testing
- `cargo check -p clappy-cli` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6842323c35e0832dacc1a56cb04a3720